### PR TITLE
Make lxmls package modules importable after package installation.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,13 @@ Dependencies
 
 Installation
 
-    - Install the requirement via pip
+    - Install the package and all requirements using pip:
+        - pip install lxmls-toolkit
+        (or 'pip install .' inside project folder)
+
+    - If everything went smoothly, you're done.
+
+    - If you got errors installing the requirements, run:
         - pip install -r pip-requirements.txt
+        - pip install .
 

--- a/lxmls/classifiers/gaussian_naive_bayes.py
+++ b/lxmls/classifiers/gaussian_naive_bayes.py
@@ -1,7 +1,7 @@
 import numpy as np
-import scipy as scipy
-import linear_classifier as lc
-from distributions.gaussian import *
+
+from . import linear_classifier as lc
+from ..distributions.gaussian import *
 
 
 class GaussianNaiveBayes(lc.LinearClassifier):

--- a/lxmls/classifiers/max_ent_batch.py
+++ b/lxmls/classifiers/max_ent_batch.py
@@ -1,8 +1,9 @@
-import sys
 import numpy as np
 import scipy.optimize.lbfgsb as opt2
-from util.my_math_utils import *
-import linear_classifier as lc
+
+from ..util.my_math_utils import *
+from . import linear_classifier as lc
+
 
 ################
 ### Train a maxent in a batch setting using LBFGS

--- a/lxmls/classifiers/max_ent_online.py
+++ b/lxmls/classifiers/max_ent_online.py
@@ -1,8 +1,8 @@
-import sys
 import numpy as np
-import scipy.optimize.lbfgsb as opt2
-from util.my_math_utils import *
-import linear_classifier as lc
+
+from ..util.my_math_utils import *
+from . import linear_classifier as lc
+
 
 ################
 ### Train a maxent in a online setting using stochastic gradient

--- a/lxmls/classifiers/mira.py
+++ b/lxmls/classifiers/mira.py
@@ -1,7 +1,8 @@
-import sys
 import numpy as np
-import linear_classifier as lc
-from util.my_math_utils import *
+
+from . import linear_classifier as lc
+from ..util.my_math_utils import *
+
 
 class Mira(lc.LinearClassifier):
 

--- a/lxmls/classifiers/multinomial_naive_bayes.py
+++ b/lxmls/classifiers/multinomial_naive_bayes.py
@@ -1,8 +1,7 @@
 import numpy as np
-import scipy as scipy
-import linear_classifier as lc
-import sys
-from distributions.gaussian import *
+
+from . import linear_classifier as lc
+from ..distributions.gaussian import *
 
 
 class MultinomialNaiveBayes(lc.LinearClassifier):

--- a/lxmls/classifiers/naive_bayes.py
+++ b/lxmls/classifiers/naive_bayes.py
@@ -1,9 +1,7 @@
 import numpy as np
-import scipy as scipy
-import linear_classifier as lc
-import sys
-from distributions.gaussian import *
-#from util.gaussian import *
+
+from . import linear_classifier as lc
+from ..distributions.gaussian import *
 
 
 class NaiveBayes(lc.LinearClassifier):

--- a/lxmls/classifiers/perceptron.py
+++ b/lxmls/classifiers/perceptron.py
@@ -1,6 +1,7 @@
-import sys
 import numpy as np
-import linear_classifier as lc
+
+from . import linear_classifier as lc
+
 
 class Perceptron(lc.LinearClassifier):
 

--- a/lxmls/classifiers/svm.py
+++ b/lxmls/classifiers/svm.py
@@ -1,7 +1,8 @@
-import sys
 import numpy as np
-import linear_classifier as lc
-from util.my_math_utils import *
+
+from . import linear_classifier as lc
+from ..util.my_math_utils import *
+
 
 class SVM(lc.LinearClassifier):
 

--- a/lxmls/labs/day0.py
+++ b/lxmls/labs/day0.py
@@ -1,6 +1,8 @@
-import numpy as np
 import math
+
+import numpy as np
 import matplotlib.pyplot as plt
+
 
 ## Exercise about gradient descent
 

--- a/lxmls/labs/day1.py
+++ b/lxmls/labs/day1.py
@@ -1,20 +1,14 @@
 ###### Exercises for pratica class 1
-import sys
-sys.path.append("readers/" )
-sys.path.append("classifiers/" )
 
-import simple_data_set as sds
-import sentiment_reader as srs
-import linear_classifier as lcc
-import perceptron as percc
-import mira as mirac
-import gaussian_naive_bayes as gnbc
-import multinomial_naive_bayes as mnb
-import max_ent_batch as mebc
-import max_ent_online as meoc
-import svm as svmc
-import naive_bayes as nb
-import run_all_classifiers as run_all_c
+from lxmls.readers import simple_data_set as sds
+from lxmls.readers import sentiment_reader as srs
+from lxmls.classifiers import perceptron as percc
+from lxmls.classifiers import mira as mirac
+from lxmls.classifiers import gaussian_naive_bayes as gnbc
+from lxmls.classifiers import multinomial_naive_bayes as mnb
+from lxmls.classifiers import max_ent_batch as mebc
+from lxmls.classifiers import max_ent_online as meoc
+from lxmls.classifiers import svm as svmc
 
 
 #### Exercise 3.1 ####

--- a/lxmls/labs/run_all_classifiers.py
+++ b/lxmls/labs/run_all_classifiers.py
@@ -1,17 +1,10 @@
-import sys
-sys.path.append("readers/" )
-sys.path.append("classifiers/" )
 
-import simple_data_set as sds
-
-import linear_classifier as lcc
-import naive_bayes as nbc
-import perceptron as percc
-import svm as svmc
-import mira as mirac
-import max_ent_batch as mec_batch
-import max_ent_online as mec_online
-
+from lxmls.classifiers import naive_bayes as nbc
+from lxmls.classifiers import perceptron as percc
+from lxmls.classifiers import svm as svmc
+from lxmls.classifiers import mira as mirac
+from lxmls.classifiers import max_ent_batch as mec_batch
+from lxmls.classifiers import max_ent_online as mec_online
 
 
 def run_all_classifiers(dataset):

--- a/lxmls/parsing/dependency_decoder.py
+++ b/lxmls/parsing/dependency_decoder.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 
 

--- a/lxmls/parsing/dependency_features.py
+++ b/lxmls/parsing/dependency_features.py
@@ -1,7 +1,6 @@
-import sys
 import numpy as np
-from scipy.sparse import lil_matrix
-from dependency_reader import *
+
+from .dependency_reader import *
 
 
 class DependencyFeatures():

--- a/lxmls/parsing/dependency_parser.py
+++ b/lxmls/parsing/dependency_parser.py
@@ -1,10 +1,10 @@
-import sys
 import numpy as np
-from dependency_reader import * 
-from dependency_writer import * 
-from dependency_features import * 
-from dependency_decoder import * 
-from util.my_math_utils import *
+
+from .dependency_reader import * 
+from .dependency_writer import * 
+from .dependency_features import * 
+from .dependency_decoder import * 
+from ..util.my_math_utils import *
 
 
 class DependencyParser():

--- a/lxmls/parsing/dependency_reader.py
+++ b/lxmls/parsing/dependency_reader.py
@@ -1,6 +1,3 @@
-import sys
-import numpy as np
-import os
 from os import path
 
 

--- a/lxmls/parsing/dependency_writer.py
+++ b/lxmls/parsing/dependency_writer.py
@@ -1,7 +1,5 @@
-import sys
-import numpy as np
-import os
 from os import path
+
 
 class DependencyWriter():
     '''

--- a/lxmls/pos_tagging/all_train_pos_tag.py
+++ b/lxmls/pos_tagging/all_train_pos_tag.py
@@ -1,19 +1,15 @@
-import sys
-import codecs
-
-from sequences.sequence import *
-from sequences.sequence_list import *
-import readers.pos_corpus as pcc
-import readers.brown_pos_corpus as bpc
-import sequences.extended_feature as exfc
-import sequences.structured_perceptron as spc
-import sequences.confusion_matrix as bcm
-
+from ..sequences.sequence import *
+from ..sequences.sequence_list import *
+from ..sequences import extended_feature as exfc
+from ..sequences import structured_perceptron as spc
+from ..readers import pos_corpus as pcc
 
 
 MAX_SENT_SIZE=1000
 MAX_NR_SENTENCES=100000
+# FIXME: hardcoded path
 MODEL_DIR="/Users/graca/Projects/swm_src/feeds/models/all_data_postag/"
+
 
 def build_corpus_features():
     corpus = pcc.PostagCorpus()

--- a/lxmls/pos_tagging/train_pos_tag.py
+++ b/lxmls/pos_tagging/train_pos_tag.py
@@ -1,12 +1,12 @@
-import readers.pos_corpus as pcc
-import sequences.extended_feature as exfc
-import sequences.structured_perceptron as spc
-
+from ..readers import pos_corpus as pcc
+from ..sequences import extended_feature as exfc
+from ..sequences import structured_perceptron as spc
 
 
 MAX_SENT_SIZE=1000
 MAX_NR_SENTENCES=100000
 MODEL_DIR="../models/wsj_postag/"
+
 
 def build_corpus_features():
     corpus = pcc.PostagCorpus()

--- a/lxmls/readers/brown_pos_corpus.py
+++ b/lxmls/readers/brown_pos_corpus.py
@@ -1,7 +1,7 @@
 from nltk.corpus import brown
-import sys
-from sequences.sequence import *
-from sequences.sequence_list import *
+
+from ..sequences.sequence import *
+from ..sequences.sequence_list import *
 
 
 class Brown_Postag:

--- a/lxmls/readers/pos_corpus.py
+++ b/lxmls/readers/pos_corpus.py
@@ -1,13 +1,14 @@
 import codecs
 import gzip
-from sequences.sequence import *
-from sequences.sequence_list import *
+
+from ..sequences.sequence import *
+from ..sequences.sequence_list import *
 
 #from nltk.corpus import brown
 
 
 ## Directory where the data files are located.
-data_dir = "../../data/"
+data_dir = "../../data/"  # TODO: Check if this broke after package installation
 
 ### Train and test files for english WSJ part of the Penn Tree Bank
 en_train = data_dir+"train-02-21.conll"

--- a/lxmls/readers/sentiment_reader.py
+++ b/lxmls/readers/sentiment_reader.py
@@ -1,11 +1,9 @@
 ### http://www.scipy.org/SciPyPackages/Sparse
 
-
-import codecs
+from os import path
 
 import numpy as np
-import os
-from os import path
+
 
 class SentimentCorpus:
     

--- a/lxmls/readers/simple_data_set.py
+++ b/lxmls/readers/simple_data_set.py
@@ -1,6 +1,6 @@
-
 import numpy as np
 import matplotlib.pyplot as plt
+
 
 class SimpleDataSet():
     ''' A simple two dimentional dataset for visualization purposes. The date set contains points from two gaussians with mean u_i and std_i'''

--- a/lxmls/readers/simple_sequence.py
+++ b/lxmls/readers/simple_sequence.py
@@ -1,6 +1,5 @@
-import sys
-from sequences.sequence import *
-from sequences.sequence_list import *
+from ..sequences.sequence import *
+from ..sequences.sequence_list import *
 
 
 ################

--- a/lxmls/run_all_classifiers.py
+++ b/lxmls/run_all_classifiers.py
@@ -1,17 +1,10 @@
-import sys
-sys.path.append("readers/" )
-sys.path.append("classifiers/" )
 
-import simple_data_set as sds
-
-import linear_classifier as lcc
-import naive_bayes as nbc
-import perceptron as percc
-import svm as svmc
-import mira as mirac
-import max_ent_batch as mec_batch
-import max_ent_online as mec_online
-
+from .classifiers import naive_bayes as nbc
+from .classifiers import perceptron as percc
+from .classifiers import svm as svmc
+from .classifiers import mira as mirac
+from .classifiers import max_ent_batch as mec_batch
+from .classifiers import max_ent_online as mec_online
 
 
 def run_all_classifiers(dataset):

--- a/lxmls/sequences/abstract_feature_class.py
+++ b/lxmls/sequences/abstract_feature_class.py
@@ -1,0 +1,89 @@
+
+
+class AbstractFeatureClass(object):
+    ''' Defines an abstract feature class used to
+    build the node and edge potentials.
+
+       All feature classes should implement this class
+    '''
+
+    def __init__(self,dataset):
+        self.feature_dic = {}
+        self.feature_names = []
+        self.nr_feats = 0
+        self.feature_list = []
+        self.add_features = False
+        self.dataset = dataset
+        #Speed up
+        self.node_feature_cache = {}
+        self.initial_state_feature_cache = {}
+        self.final_state_feature_cache = {}
+        self.edge_feature_cache = {}
+
+
+    def build_features(self):
+        '''
+        Generic function to build features for a given dataset.
+        Iterates through all sentences in the dataset and extracts its features,
+        saving the node/edge features in feature list.
+        '''
+        self.add_features = True
+        for seq in self.dataset.sequence_list.seq_list:
+           seq_node_features,seq_edge_features = self.get_seq_features(seq)
+           self.feature_list.append([seq_node_features,seq_edge_features])
+        self.nr_feats = len(self.feature_names)
+        self.add_features = False
+
+
+
+    def get_nr_features(self):
+        ''' returns the number of existing features
+        '''
+        raise NotImplementedError
+
+    def get_edge_features(self,sequence,position,tag_id,prev_tag_id):
+        '''
+        Returns the edge features for position, for
+        previous tag_id and tag_id.
+
+        Note for a sentence of lenght N pos can go from 0 to N.
+        Where:
+        0 - Takes the initial transition features
+        N - Takes the final transition features        
+        '''
+        raise NotImplementedError
+
+    def get_node_features(self,sequence,position,tag_id):
+        '''
+        Returns all features for a node at position with tag_id
+        '''
+        raise NotImplementedError
+
+    def save_features(self,file):
+        fn = open(file,"w")
+        for feat_nr,feat in enumerate(self.feature_names):
+            fn.write("%i\t%s\n"%(feat_nr,feat))
+        fn.close()
+
+
+    ###########
+    # Loads all features form a file
+    ###########
+    def load_features(self,file,dataset):
+        fn = open(file)
+        self.feature_names = []
+        self.feature_dic = {}
+        for line in fn:
+            feat_nr,feat = line.strip().split("\t")
+            self.feature_names.append(feat)
+            self.feature_dic[feat] = int(feat_nr)
+        self.feature_list = []
+        self.nr_feats = len(self.feature_names)
+        self.add_features = False
+        self.dataset = dataset
+        fn.close()
+        #Speed up
+        self.node_feature_cache = {}
+        self.initial_state_feature_cache = {}
+        self.edge_feature_cache = {}
+        self.final_edge_feature_cache = {}    

--- a/lxmls/sequences/basic_feature.py
+++ b/lxmls/sequences/basic_feature.py
@@ -1,4 +1,5 @@
-import id_feature as idf
+from . import id_feature as idf
+
 
 class BasicFeatures(idf.IDFeatures):
 

--- a/lxmls/sequences/confusion_matrix.py
+++ b/lxmls/sequences/confusion_matrix.py
@@ -1,9 +1,7 @@
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-from util.my_math_utils import *
-from itertools import izip
-import operator
+
+from ..util.my_math_utils import *
 
 ## Colour for each pos tag
 tag_colors = {

--- a/lxmls/sequences/crf_batch.py
+++ b/lxmls/sequences/crf_batch.py
@@ -1,14 +1,10 @@
-import sys
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy import optimize
 
+from ..util.my_math_utils import *
+from .forward_backward import forward_backward
+from . import discriminative_sequence_classifier as dsc
 
-
-from util.my_math_utils import *
-from viterbi import viterbi
-from forward_backward import forward_backward,sanity_check_forward_backward
-import discriminative_sequence_classifier as dsc
 
 class CRF_batch(dsc.DiscriminativeSequenceClassifier):
     ''' Implements a first order CRF'''

--- a/lxmls/sequences/crf_batch_debug.py
+++ b/lxmls/sequences/crf_batch_debug.py
@@ -1,15 +1,10 @@
-import sys
 import numpy as np
-import matplotlib.pyplot as plt
 from scipy import optimize
 
-sys.path.append("util/" )
+from ..util.my_math_utils import *
+from .forward_backward import forward_backward
+from . import discriminative_sequence_classifier as dsc
 
-from my_math_utils import *
-from viterbi import viterbi
-from forward_backward import forward_backward,sanity_check_forward_backward
-sys.path.append("sequences/" )
-import discriminative_sequence_classifier as dsc
 
 class CRF_batch(dsc.DiscriminativeSequenceClassifier):
     ''' Implements a first order CRF'''

--- a/lxmls/sequences/discriminative_sequence_classifier.py
+++ b/lxmls/sequences/discriminative_sequence_classifier.py
@@ -1,18 +1,15 @@
 
-import sys
 import numpy as np
-import matplotlib.pyplot as plt
-sys.path.append("util/" )
 
-from my_math_utils import *
-from viterbi import viterbi
-from viterbi_2 import viterbi_log
-from forward_backward import forward_backward,sanity_check_forward_backward
+from ..util.my_math_utils import *
+from .viterbi import viterbi
+from .viterbi_2 import viterbi_log
+from .forward_backward import forward_backward
+
 
 class DiscriminativeSequenceClassifier():
 
 
-    
     def __init__(self,dataset,feature_class):
         self.trained = False
         self.feature_class = feature_class

--- a/lxmls/sequences/em.py
+++ b/lxmls/sequences/em.py
@@ -1,10 +1,6 @@
-import sys
-import numpy as np
-from viterbi import viterbi
-from forward_backward import forward_backward,sanity_check_forward_backward
-sys.path.append("util/" )
-from my_math_utils import *
-from confusion_matrix import *
+from ..util.my_math_utils import *
+from .confusion_matrix import *
+
 
 class EM():
 

--- a/lxmls/sequences/extended_feature.py
+++ b/lxmls/sequences/extended_feature.py
@@ -1,5 +1,6 @@
 
-from id_feature import IDFeatures
+from .id_feature import IDFeatures
+
 
 #######################
 #### Feature Class

--- a/lxmls/sequences/hmm.py
+++ b/lxmls/sequences/hmm.py
@@ -1,10 +1,9 @@
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-from util.my_math_utils import *
-from viterbi import viterbi
-from forward_backward import forward_backward,sanity_check_forward_backward
 
+from ..util.my_math_utils import *
+from .viterbi import viterbi
+from .forward_backward import forward_backward, sanity_check_forward_backward
 
 
 class HMM():

--- a/lxmls/sequences/hmm_n_order.py
+++ b/lxmls/sequences/hmm_n_order.py
@@ -1,11 +1,10 @@
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
-sys.path.append("util/" )
 
-from my_math_utils import *
-from viterbi import viterbi
-from forward_backward import forward_backward,sanity_check_forward_backward
+from ..util.my_math_utils import *
+from .viterbi import viterbi
+from .forward_backward import forward_backward
+
 
 #######
 ## Sum all the entries in a dictionary of dictionaries

--- a/lxmls/sequences/hmm_second_order.py
+++ b/lxmls/sequences/hmm_second_order.py
@@ -1,13 +1,8 @@
-import sys
 import numpy as np
 
-import matplotlib.pyplot as plt
-sys.path.append("util/" )
-
-from my_math_utils import *
-from viterbi import viterbi
-from forward_backward import forward_backward,sanity_check_forward_backward
-
+from ..util.my_math_utils import *
+from .viterbi import viterbi
+from .forward_backward import forward_backward, sanity_check_forward_backward
 
 
 class HMM_Second_Order():

--- a/lxmls/sequences/id_feature.py
+++ b/lxmls/sequences/id_feature.py
@@ -1,5 +1,6 @@
 
-from abstract_feature_class import AbstractFeatureClass
+from .abstract_feature_class import AbstractFeatureClass
+
 
 #################
 ### Replicates teh same features as the HMM

--- a/lxmls/sequences/sequence.py
+++ b/lxmls/sequences/sequence.py
@@ -1,4 +1,5 @@
-import sys
+
+
 class Sequence:
     def __init__(self,sequence_list,x,y,nr):
         self.x = x

--- a/lxmls/sequences/sequence_list.py
+++ b/lxmls/sequences/sequence_list.py
@@ -1,4 +1,5 @@
-import sequence as seq
+from . import sequence as seq
+
 
 class Sequence_List:
     def __init__(self,x_dict,int_to_word,y_dict,int_to_pos):

--- a/lxmls/sequences/structured_perceptron.py
+++ b/lxmls/sequences/structured_perceptron.py
@@ -1,18 +1,8 @@
-import sys
 import numpy as np
-import matplotlib.pyplot as plt
-import scipy.optimize.lbfgsb as opt2
-sys.path.append("util/" )
 
+from ..util.my_math_utils import *
+from . import discriminative_sequence_classifier as dsc
 
-import sys
-import numpy as np
-import matplotlib.pyplot as plt
-sys.path.append("util/" )
-from my_math_utils import *
-from forward_backward import forward_backward,sanity_check_forward_backward
-sys.path.append("sequences/" )
-import discriminative_sequence_classifier as dsc
 
 class StructuredPercetron(dsc.DiscriminativeSequenceClassifier):
     ''' Implements a first order CRF'''

--- a/lxmls/util/my_math_utils.py
+++ b/lxmls/util/my_math_utils.py
@@ -2,8 +2,8 @@ import numpy as np
 from scipy import *
 from scipy.sparse import *
 
-from itertools import izip
 import operator
+
 
 def sort_dic_by_value (dic,reverse=False):
     return sorted(dic.iteritems(), key=operator.itemgetter(1),reverse=reverse)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
+
 
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
@@ -9,19 +10,27 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name = "LXMLS_Toolkit",
-    version = "0.0.1",
-    author = "Joao Graca",
-    author_email = "gracaninja@gmail.com",
-    description = ("Machine Learning and Natural Language toolkit"),
-    license = "BSD",
-    keywords = "machine learning",
-    url = "http://none",
-    packages=['lxmls'],
-    long_description=read('README'),
+    name="LXMLS_Toolkit",
+    version="0.0.1",
+    author="Joao Graca",
+    author_email="gracaninja@gmail.com",
+    description=("Machine Learning and Natural Language toolkit"),
+    license="BSD",
+    keywords="machine learning",
+    url="https://github.com/gracaninja/lxmls-toolkit",
+    long_description=read('README.txt'),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Topic :: Utilities",
         "License :: OSI Approved :: BSD License",
     ],
+    packages=find_packages(exclude=("code", "code.*")),
+    install_requires=[
+        "pyyaml",
+        "configparser >= 3.2.0",
+        "nltk",
+        "matplotlib",
+        "numpy",
+        "scipy"
+    ]
 )


### PR DESCRIPTION
This patch allows lxmls-toolkit subpackages and modules to be imported after the package is installed using pip.

Since now all intra-package imports are relative, to directly run scripts inside the lxmls package, the python interpreter should be invoked in the lxmls-toolkit root directory with the module option, like:
python -m lxmls.package.module

Changes:
- Updated setup.py with find_packages() and install_requires;
- Made all intra-package imports relative;
- Removed unused imports;
- Update README.txt.

TODO:
- Assure the data dir is installed alongside the package and all access to it is working.
