### PR TITLE
Fix in MaxEnt_Batch: enumerate() returns (index, value) and not (value, index)

### DIFF
--- a/lxmls/classifiers/max_ent_batch.py
+++ b/lxmls/classifiers/max_ent_batch.py
@@ -22,7 +22,7 @@ class MaxEnt_batch(lc.LinearClassifier):
         init_parameters = np.zeros((nr_f,nr_c),dtype=float)
         emp_counts = np.zeros((nr_f,nr_c))
         classes_idx = []
-        for c,c_i in enumerate(classes):
+        for c_i, c in enumerate(classes):
             idx,_ = np.nonzero(y == c)
             classes_idx.append(idx)
             emp_counts[:,c_i] = x[idx,:].sum(0)            


### PR DESCRIPTION
The current code works only if class names are integer starting with 0.
np.unique(...) returns something like [0,1,2,3], so enumerate(classes) = [(0,0), (1,1), (2,2), (3,3)] => c == c_i.
If other class id are used, it will not work.
