### PR TITLE
NOTEBOOK: parsing

### DIFF
--- a/labs/notebooks/parsing/exercise_3.ipynb
+++ b/labs/notebooks/parsing/exercise_3.ipynb
@@ -1,0 +1,427 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this exercise you are going to experiment with arc-factored non-projective dependency parsers. The CoNLL-X and CoNLL 2008 shared task datasets (Buchholz and Marsi, 2006; Surdeanu et al., 2008) contain dependency treebanks for 14 languages. In this lab, we are going to experiment with the Portuguese and English datasets. We preprocessed those datasets to exclude all sentences with more than 15 words; this yielded the files:\n",
+    "\n",
+    "* data/deppars/portuguese train.conll,\n",
+    "* data/deppars/portuguese test.conll,\n",
+    "* data/deppars/english train.conll,\n",
+    "* data/deppars/english test.conll.\n",
+    "\n",
+    "1) After importing all the necessary libraries, load the Portuguese dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of sentences: 3029\n",
+      "Number of tokens: 25015\n",
+      "Number of words: 7621\n",
+      "Number of pos: 16\n",
+      "Number of features: 142\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../../../\")\n",
+    "import lxmls.parsing.dependency_parser as depp\n",
+    "dp = depp.DependencyParser()\n",
+    "dp.read_data(\"portuguese\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Observe the statistics which are shown. How many features are there in total?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2) We will now have a close look on the features that can be used in the parser. Examine the file:\n",
+    "\n",
+    "```lxmls/parsing/dependency features.py.```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following method takes a sentence and computes a vector of features for each possible arc\n",
+    "\n",
+    "```<h, m>:```\n",
+    "\n",
+    "```python\n",
+    "def create_arc_features(self, instance, h, m, add=False):\n",
+    "    '''Creates features for arc h-->m.'''\n",
+    "```\n",
+    "\n",
+    "We grouped the features in several subsets, so that we can conduct some ablation experiments:\n",
+    "\n",
+    "* Basic features that look only at the parts-of-speech of the words that can be connected by an arc\n",
+    "* Lexical features that also look at these words themselves;\n",
+    "* Distance features that look at the length and direction of the dependency link (i.e., distance between the two words);\n",
+    "* Contextual features that look at the context (part-of-speech tags) of the words surrounding h and m.\n",
+    "\n",
+    "In the default configuration, only the basic features are enabled. The total number of features is the quantity observed in the previous question. With this configuration, train the parser by running 10 epochs of the structured perceptron algorithm:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of sentences: 3029\n",
+      "Number of tokens: 25015\n",
+      "Number of words: 7621\n",
+      "Number of pos: 16\n",
+      "Number of features: 142\n",
+      "Epoch 1\n",
+      "Training accuracy: 0.497432605905\n",
+      "Epoch 2\n",
+      "Training accuracy: 0.499144201968\n",
+      "Epoch 3\n",
+      "Training accuracy: 0.498217087434\n",
+      "Epoch 4\n",
+      "Training accuracy: 0.50053487377\n",
+      "Epoch 5\n",
+      "Training accuracy: 0.501818570817\n",
+      "Epoch 6\n",
+      "Training accuracy: 0.498538011696\n",
+      "Epoch 7\n",
+      "Training accuracy: 0.500962772786\n",
+      "Epoch 8\n",
+      "Training accuracy: 0.500285266011\n",
+      "Epoch 9\n",
+      "Training accuracy: 0.499286834974\n",
+      "Epoch 10\n",
+      "Training accuracy: 0.500035658251\n"
+     ]
+    }
+   ],
+   "source": [
+    "import lxmls.parsing.dependency_parser as depp\n",
+    "dp = depp.DependencyParser()\n",
+    "dp.read_data(\"portuguese\")\n",
+    "dp.train_perceptron(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<bound method DependencyParser.test of <lxmls.parsing.dependency_parser.DependencyParser instance at 0x00000000088C5EC8>>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dp.test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What is the accuracy obtained in the test set? (Note: the shown accuracy is the fraction of words whose parent was correctly predicted.)\n",
+    "\n",
+    "3) Repeat the previous exercise by subsequently enabling the lexical, distance and contextual features:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of sentences: 3029\n",
+      "Number of tokens: 25015\n",
+      "Number of words: 7621\n",
+      "Number of pos: 16\n",
+      "Number of features: 46216\n",
+      "Epoch 1\n",
+      "Training accuracy: 0.531914134931\n",
+      "Epoch 2\n",
+      "Training accuracy: 0.641135358722\n",
+      "Epoch 3\n",
+      "Training accuracy: 0.722864070746\n",
+      "Epoch 4\n",
+      "Training accuracy: 0.784695478534\n",
+      "Epoch 5\n",
+      "Training accuracy: 0.820425046356\n",
+      "Epoch 6\n",
+      "Training accuracy: 0.851911282271\n",
+      "Epoch 7\n",
+      "Training accuracy: 0.873876765083\n",
+      "Epoch 8\n",
+      "Training accuracy: 0.890850092711\n",
+      "Epoch 9\n",
+      "Training accuracy: 0.897054628441\n",
+      "Epoch 10\n",
+      "Training accuracy: 0.907466837826\n",
+      "Test accuracy (109 test instances): 0.57662835249\n"
+     ]
+    }
+   ],
+   "source": [
+    "dp.features.use_lexical = True \n",
+    "dp.read_data(\"portuguese\") \n",
+    "dp.train_perceptron(10) \n",
+    "dp.test()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dp.features.use_distance = True\n",
+    "dp.read_data(\"portuguese\") \n",
+    "dp.train_perceptron(10) \n",
+    "dp.test()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dp.features.use_contextual = True \n",
+    "dp.read_data(\"portuguese\") \n",
+    "dp.train_perceptron(10)\n",
+    "dp.test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each configuration, write down the number of features and test set accuracies. Observe the improvements obtained when more features were added. Feel free to engineer new features!\n",
+    "\n",
+    "4) Which of the three important inference tasks discussed above (computing the most likely tree, computing the partition function, and computing the marginals) need to be performed in the structured perceptron algorithm? What about a maximum entropy classifier, with stochastic gradient descent? Check your answers by looking at the following two methods in code/dependency parser.py:\n",
+    "\n",
+    "```python\n",
+    "def train_perceptron(self, n_epochs): ...\n",
+    "```\n",
+    "\n",
+    "```python\n",
+    "def train_crf_sgd(self, n_epochs, sigma, eta0 = 0.001): ...\n",
+    "```\n",
+    "\n",
+    "Repeat the last exercise by training a maximum entropy classifier, with stochastic gradient descent, using $l$ = 0.01 and a initial stepsize of $\\eta_0$ = 0.1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dp.train_crf_sgd(10, 0.01, 0.1)\n",
+    "dp.test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare the results with those obtained by the perceptron algorithm.\n",
+    "\n",
+    "5) Train a parser for English using your favourite learning algorithm:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dp.read_data(\"english\")\n",
+    "dp.train_perceptron(10)\n",
+    "dp.test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The predicted trees are placed in the file data/deppars/english_test.conll.pred. To get a sense of which errors are being made, you can check the sentences that differ from the gold standard (see the data in data/deppars/english_test.conll) and visualize those sentences, e.g., in https://brenocon.com/parseviz/."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "6) (*Optional.*) Implement Eisner’s algorithm for projective dependency parsing. The pseudo-code is shown as Algorithm 13. Implement this algorithm as the function:\n",
+    "\n",
+    "```python\n",
+    "def parse_proj(self, scores):\n",
+    "```\n",
+    "in file `dependency_decoder.py`. The input is a matrix of arc scores, whose dimension is $(N + 1)$-by-$(N + 1)$, and whose $(h, m)$ entry contains the score $s_\\sigma(h, m)$.\n",
+    "\n",
+    "In particular, the first row contains the scores for the arcs that depart from the root, and the first column's values, along with the main diagonal, are to be ignored (since no arcs point to the root, and there are no self-pointing arcs). To make your job easier, we provide an implementation of the backtracking part:\n",
+    "\n",
+    "```python\n",
+    "def backtrack_eisner(self, incomplete_backtrack, complete_backtrack, s, t, direction, complete, heads):\n",
+    "```\n",
+    "\n",
+    "so you just need to build complete/incomplete spans and their backtrack pointers and then call.\n",
+    "\n",
+    "```python\n",
+    "    heads = -np.ones(N+1, dtype=int) \n",
+    "    self.backtrack_eisner(incomplete_backtrack, complete_backtrack, 0, N, 1, 1,heads)\n",
+    "    return heads\n",
+    "```\n",
+    "to obtain the final parse. To test the algorithm, retrain the parser on the English data (where the trees are actually all projective) by setting the flag dp.projective to True:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dp = depp.DependencyParser() \n",
+    "dp.features.use_lexical = True \n",
+    "dp.features.use_distance = True \n",
+    "dp.features.use_contextual = True \n",
+    "dp.read_data(\"english\") \n",
+    "dp.projective = True\n",
+    "dp.train_perceptron(10)\n",
+    "dp.test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You should get the following results:\n",
+    "\n",
+    "```\n",
+    "￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼￼4.2.5\n",
+    "Number of sentences: 8044\n",
+    "Number of tokens: 80504\n",
+    "Number of words: 12202\n",
+    "Number of pos: 48\n",
+    "Number of features: 338014\n",
+    "Epoch 1\n",
+    "Training accuracy: 0.835637168541\n",
+    "Epoch 2\n",
+    "Training accuracy: 0.922426254687\n",
+    "Epoch 3\n",
+    "Training accuracy: 0.947621628947\n",
+    "Epoch 4\n",
+    "Training accuracy: 0.960326602521\n",
+    "Epoch 5\n",
+    "Training accuracy: 0.967689840538\n",
+    "Epoch 6\n",
+    "Training accuracy: 0.97263631025\n",
+    "Epoch 7\n",
+    "Training accuracy: 0.97619370285\n",
+    "Epoch 8\n",
+    "Training accuracy: 0.979209016579\n",
+    "Epoch 9\n",
+    "Training accuracy: 0.98127569228\n",
+    "Epoch 10\n",
+    "Training accuracy: 0.981320865519\n",
+    "Test accuracy (509 test instances): 0.886732599366\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/labs/notebooks/parsing/exercise_3.ipynb
+++ b/labs/notebooks/parsing/exercise_3.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### The Portuguese Dataset\n",
+    "\n",
     "In this exercise you are going to experiment with arc-factored non-projective dependency parsers. The CoNLL-X and CoNLL 2008 shared task datasets (Buchholz and Marsi, 2006; Surdeanu et al., 2008) contain dependency treebanks for 14 languages. In this lab, we are going to experiment with the Portuguese and English datasets. We preprocessed those datasets to exclude all sentences with more than 15 words; this yielded the files:\n",
     "\n",
     "* data/deppars/portuguese train.conll,\n",
@@ -11,7 +13,7 @@
     "* data/deppars/english train.conll,\n",
     "* data/deppars/english test.conll.\n",
     "\n",
-    "1) After importing all the necessary libraries, load the Portuguese dataset:"
+    "After importing all the necessary libraries, load the Portuguese dataset:"
    ]
   },
   {
@@ -47,19 +49,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "2) We will now have a close look on the features that can be used in the parser. Examine the file:\n",
+    "### Examining Features\n",
+    "\n",
+    "We will now have a close look on the features that can be used in the parser. Examine the file:\n",
     "\n",
     "```lxmls/parsing/dependency features.py.```"
    ]
@@ -68,9 +63,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following method takes a sentence and computes a vector of features for each possible arc\n",
-    "\n",
-    "```<h, m>:```\n",
+    "The following method takes a sentence and computes a vector of features for each possible arc $\\langle h, m \\rangle$:\n",
     "\n",
     "```python\n",
     "def create_arc_features(self, instance, h, m, add=False):\n",
@@ -79,10 +72,10 @@
     "\n",
     "We grouped the features in several subsets, so that we can conduct some ablation experiments:\n",
     "\n",
-    "* Basic features that look only at the parts-of-speech of the words that can be connected by an arc\n",
-    "* Lexical features that also look at these words themselves;\n",
-    "* Distance features that look at the length and direction of the dependency link (i.e., distance between the two words);\n",
-    "* Contextual features that look at the context (part-of-speech tags) of the words surrounding h and m.\n",
+    "* **Basic** features that look only at the parts-of-speech of the words that can be connected by an arc;\n",
+    "* **Lexical** features that also look at these words themselves;\n",
+    "* **Distance** features that look at the length and direction of the dependency link (i.e., distance between the two words);\n",
+    "* **Contextual** features that look at the context (part-of-speech tags) of the words surrounding h and m.\n",
     "\n",
     "In the default configuration, only the basic features are enabled. The total number of features is the quantity observed in the previous question. With this configuration, train the parser by running 10 epochs of the structured perceptron algorithm:"
    ]
@@ -133,40 +126,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<bound method DependencyParser.test of <lxmls.parsing.dependency_parser.DependencyParser instance at 0x00000000088C5EC8>>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test accuracy (109 test instances): 0.57662835249\n"
+     ]
     }
    ],
    "source": [
-    "dp.test"
+    "dp.test()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What is the accuracy obtained in the test set? (Note: the shown accuracy is the fraction of words whose parent was correctly predicted.)\n",
+    "What is the accuracy obtained in the test set? (Note: the shown accuracy is the fraction of words whose parent was correctly predicted.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding Features\n",
     "\n",
-    "3) Repeat the previous exercise by subsequently enabling the lexical, distance and contextual features:"
+    "Repeat the previous exercise by subsequently enabling the lexical, distance and contextual features:"
    ]
   },
   {
@@ -216,11 +204,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of sentences: 3029\n",
+      "Number of tokens: 25015\n",
+      "Number of words: 7621\n",
+      "Number of pos: 16\n",
+      "Number of features: 46224\n",
+      "Epoch 1\n",
+      "Training accuracy: 0.700292397661\n",
+      "Epoch 2\n",
+      "Training accuracy: 0.790757381258\n",
+      "Epoch 3\n",
+      "Training accuracy: 0.844815290258\n",
+      "Epoch 4\n",
+      "Training accuracy: 0.878155755242\n",
+      "Epoch 5\n",
+      "Training accuracy: 0.897232919698\n",
+      "Epoch 6\n",
+      "Training accuracy: 0.915703893881\n",
+      "Epoch 7\n",
+      "Training accuracy: 0.929432320639\n",
+      "Epoch 8\n",
+      "Training accuracy: 0.940379403794\n",
+      "Epoch 9\n",
+      "Training accuracy: 0.948723434603\n",
+      "Epoch 10\n",
+      "Training accuracy: 0.954999286835\n",
+      "Test accuracy (109 test instances): 0.714559386973\n"
+     ]
+    }
+   ],
    "source": [
     "dp.features.use_distance = True\n",
     "dp.read_data(\"portuguese\") \n",
@@ -230,11 +249,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of sentences: 3029\n",
+      "Number of tokens: 25015\n",
+      "Number of words: 7621\n",
+      "Number of pos: 16\n",
+      "Number of features: 92918\n",
+      "Epoch 1\n",
+      "Training accuracy: 0.825452859792\n",
+      "Epoch 2\n",
+      "Training accuracy: 0.903758379689\n",
+      "Epoch 3\n",
+      "Training accuracy: 0.933497361289\n",
+      "Epoch 4\n",
+      "Training accuracy: 0.950613321923\n",
+      "Epoch 5\n",
+      "Training accuracy: 0.960419341036\n",
+      "Epoch 6\n",
+      "Training accuracy: 0.966445585508\n",
+      "Epoch 7\n",
+      "Training accuracy: 0.973933818286\n",
+      "Epoch 8\n",
+      "Training accuracy: 0.976180288119\n",
+      "Epoch 9\n",
+      "Training accuracy: 0.982634431607\n",
+      "Epoch 10\n",
+      "Training accuracy: 0.985094850949\n",
+      "Test accuracy (109 test instances): 0.874521072797\n"
+     ]
+    }
+   ],
    "source": [
     "dp.features.use_contextual = True \n",
     "dp.read_data(\"portuguese\") \n",
@@ -246,16 +296,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For each configuration, write down the number of features and test set accuracies. Observe the improvements obtained when more features were added. Feel free to engineer new features!\n",
+    "For each configuration, write down the number of features and test set accuracies. Observe the improvements obtained when more features were added. Feel free to engineer new features!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training with MaxEnt\n",
     "\n",
-    "4) Which of the three important inference tasks discussed above (computing the most likely tree, computing the partition function, and computing the marginals) need to be performed in the structured perceptron algorithm? What about a maximum entropy classifier, with stochastic gradient descent? Check your answers by looking at the following two methods in code/dependency parser.py:\n",
+    "Which of the three important inference tasks discussed above (computing the most likely tree, computing the partition function, and computing the marginals) need to be performed in the structured perceptron algorithm? What about a maximum entropy classifier, with stochastic gradient descent? Check your answers by looking at the following two methods in code/dependency parser.py:\n",
     "\n",
     "```python\n",
-    "def train_perceptron(self, n_epochs): ...\n",
+    "def train_perceptron(self, n_epochs):\n",
+    "    ...\n",
     "```\n",
     "\n",
     "```python\n",
-    "def train_crf_sgd(self, n_epochs, sigma, eta0 = 0.001): ...\n",
+    "def train_crf_sgd(self, n_epochs, sigma, eta0 = 0.001):\n",
+    "    ...\n",
     "```\n",
     "\n",
     "Repeat the last exercise by training a maximum entropy classifier, with stochastic gradient descent, using $l$ = 0.01 and a initial stepsize of $\\eta_0$ = 0.1:"
@@ -263,11 +322,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1\n",
+      "Training objective: 4.4070880113\n",
+      "Epoch 2\n",
+      "Training objective: 3.7910577601\n",
+      "Epoch 3\n",
+      "Training objective: 3.69859794909\n",
+      "Epoch 4\n",
+      "Training objective: 3.65759775959\n",
+      "Epoch 5\n",
+      "Training objective: 3.63423975151\n",
+      "Epoch 6\n",
+      "Training objective: 3.61910334678\n",
+      "Epoch 7\n",
+      "Training objective: 3.60848000103\n",
+      "Epoch 8\n",
+      "Training objective: 3.6006052875\n",
+      "Epoch 9\n",
+      "Training objective: 3.5945303809\n",
+      "Epoch 10\n",
+      "Training objective: 3.58969896567\n",
+      "Test accuracy (109 test instances): 0.88122605364\n"
+     ]
+    }
+   ],
    "source": [
     "dp.train_crf_sgd(10, 0.01, 0.1)\n",
     "dp.test()"
@@ -277,18 +362,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Compare the results with those obtained by the perceptron algorithm.\n",
+    "Compare the results with those obtained by the perceptron algorithm."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Other Languages\n",
     "\n",
-    "5) Train a parser for English using your favourite learning algorithm:"
+    "Train a parser for English using your favourite learning algorithm:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of sentences: 8044\n",
+      "Number of tokens: 80504\n",
+      "Number of words: 12202\n",
+      "Number of pos: 48\n",
+      "Number of features: 338014\n",
+      "Epoch 1\n",
+      "Training accuracy: 0.825484482992\n",
+      "Epoch 2\n",
+      "Training accuracy: 0.918123503636\n",
+      "Epoch 3\n",
+      "Training accuracy: 0.944832181416\n",
+      "Epoch 4\n",
+      "Training accuracy: 0.959840990197\n",
+      "Epoch 5\n",
+      "Training accuracy: 0.96828838596\n",
+      "Epoch 6\n",
+      "Training accuracy: 0.973788227854\n",
+      "Epoch 7\n",
+      "Training accuracy: 0.97763924651\n",
+      "Epoch 8\n",
+      "Training accuracy: 0.981038532773\n",
+      "Epoch 9\n",
+      "Training accuracy: 0.983297194742\n",
+      "Epoch 10\n",
+      "Training accuracy: 0.985025071148\n",
+      "Test accuracy (509 test instances): 0.885612987498\n"
+     ]
+    }
+   ],
    "source": [
     "dp.read_data(\"english\")\n",
     "dp.train_perceptron(10)\n",
@@ -315,7 +438,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "6) (*Optional.*) Implement Eisner’s algorithm for projective dependency parsing. The pseudo-code is shown as Algorithm 13. Implement this algorithm as the function:\n",
+    "### Eisner's Algorithm *(optional)*\n",
+    "\n",
+    "Implement Eisner’s algorithm for projective dependency parsing. The pseudo-code is shown as Algorithm 13. Implement this algorithm as the function:\n",
     "\n",
     "```python\n",
     "def parse_proj(self, scores):\n",
@@ -392,15 +517,6 @@
     "Test accuracy (509 test instances): 0.886732599366\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is a (not yet ready to merge) pull request to fix #79.

For now I simply copied exercise 3 from David's notebooks.
Still missing:
- [x] Exercise 1/2 -- these exercises are about using external tools and viewing/thinking about results. I don't think it makes sense to make notebooks for these, but it kind of screws the file tree, since the others have 1 notebook per exercise. Do we just ignore these?
- [ ] There's a very nice Eisner explanation on David's notebook, that would make sense to have here. However, since it's very big and for an optional exercise, I'd be more comfortable with creating a separate file for the Eisner exercise. The most straightforward way to do this would be to add to the guide an optional exercise 4, to implement Eisner (as opposed to having it be part of ex. 3). Do you agree with this solution?
- [ ] Remove the `import sys; sys.path.append("../../..")`, as per #73.
- [x] Change formatting to be more consistent with the other notebooks

@ramon-astudillo need feedback for the first 2 points :)