### PR TITLE
Minor mods in 0.12, 0.13 to get plots for GD

### DIFF
--- a/labs/notebooks/basic_tutorials/Exercises_0.10_to_0.15.ipynb
+++ b/labs/notebooks/basic_tutorials/Exercises_0.10_to_0.15.ipynb
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Exercise 0.11 \n",
+    "##### Exercise 0.11 \n",
     "Consider the function $f(x) = x^2$ and its derivative \n",
     "$ \\frac{\\partial f}{\\partial x} $.\n",
     "Look at the derivative of that function at points ``[-2,0,2]``, draw the tangent to the graph in that point \n",
@@ -134,7 +134,7 @@
     "k = np.array([-2,0,2])\n",
     "plt.plot(k,k**2,\"bo\")\n",
     "for i in k:\n",
-    "    plt.plot(a, (2*i)*a - (i**2))"
+    "    plt.plot(a, (2*i)*a - i**2)"
    ]
   },
   {
@@ -243,19 +243,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "x = np.arange(-8,8,0.001)\n",
+    "y = list(map(lambda u: get_y(u),x))\n",
+    "plt.plot(x,y)\n",
     "x_0 = -8\n",
     "res = gradient_descent(x_0,get_y,get_grad)\n",
-    "plt.plot(res[:,0],res[:,1],'+')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x_0 = 8\n",
-    "res = gradient_descent(x_0,get_y,get_grad, step_size=0.01)\n",
     "plt.plot(res[:,0],res[:,1],'+')"
    ]
   },
@@ -335,6 +327,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "x = np.arange(-8,8,0.001)\n",
+    "y = list(map(lambda u: get_y(u),x))\n",
+    "plt.plot(x,y)\n",
     "plt.plot(res, (res+2)**2 - 16*np.exp(-((res-2)**2)), '+')"
    ]
   },
@@ -366,14 +361,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1) Derive the gradient of the erro $\\frac{\\partial e}{\\partial w_j}$."
+    "1) Derive the gradient of the error $\\frac{\\partial e}{\\partial w_j}$:\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "R:\n",
+    "\n",
     "\\begin{equation*}\n",
     "\\frac{\\partial e}{\\partial w_j} = \\sum_i 2 x_j^{(i)} ( x^{(i)^T} w - y^{(i)} ).\n",
     "\\end{equation*}"
@@ -409,7 +404,7 @@
    "source": [
     "# Get data.\n",
     "use_bias = True #True\n",
-    "y = galton_data[:,0] \n",
+    "y = galton_data[:,0]\n",
     "if use_bias:\n",
     "    x = np.vstack( [galton_data[:,1], np.ones(galton_data.shape[0])] )  \n",
     "else:\n",
@@ -424,7 +419,6 @@
     "\n",
     "# Initialize w.\n",
     "w = np.array([1,0])\n",
-    "\n",
     "#get_e_dev(w)"
    ]
   },
@@ -454,13 +448,12 @@
     "        error_i = np.matmul(x_new, x) - y\n",
     "        mse = np.multiply(error_i, error_i).sum()\n",
     "        mses.append(mse)\n",
-    "        print(x_new, mse)\n",
     "    return np.array(res), np.array(mses)\n",
     "\n",
     "res, mses = grad_desc(w, 0.0002, 0.00001, x,y)\n",
     "w_sgd = res[-1]\n",
     "w_sgd\n",
-    "#res"
+    "#res\n"
    ]
   },
   {
@@ -477,7 +470,7 @@
    "outputs": [],
    "source": [
     "plt.plot(res[:, 0], res[:, 1], '*')\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -486,7 +479,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(mses)\n"
+    "plt.plot(mses)"
    ]
   },
   {
@@ -512,7 +505,7 @@
    "outputs": [],
    "source": [
     "from numpy.linalg import lstsq\n",
-    "m, c = np.linalg.lstsq(x.T, y)[0]\n",
+    "m, c = np.linalg.lstsq(x.T, y)[0] #y = mx + c\n",
     "print(m,c)\n",
     "w_lstsq = np.array([m, c])\n",
     "error2  = np.multiply(y - np.matmul(w_lstsq,x), y - np.matmul(w_lstsq,x)).sum()\n",
@@ -536,6 +529,7 @@
     "plt.plot(galton_data[:,0],galton_data[:,1], \".\")\n",
     "plt.title(\"We nailed it??\")\n",
     "maxim, minim = int(np.max(galton_data[:,0])), int(np.min(galton_data[:,0]))\n",
+    "\n",
     "xvals = [vec for vec in np.array(range(minim-1, maxim+1)) ]\n",
     "\n",
     "# Gradient descent solution\n",
@@ -600,41 +594,35 @@
     "def walk():\n",
     "    iters = 0\n",
     "    x = 0\n",
+    "    \n",
     "    while x <= 1.:\n",
     "        x = next_x(x)\n",
     "        iters += 1\n",
     "    return iters\n",
     "\n",
     "\n",
-    "walks = np.array([walk() for i in range(1000)])\n",
+    "walks = np.array([walk() for i in range(100)])\n",
     "print(np.mean(walks))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In ex. 0.12 and 0.12: code for plotting `x` around `[-8, 8]` is copied into the cells with plotting the minimizing sequences to get pictures the same as on pages 26 and 28 of the tutorial, otherwise, plots are meaningless. 
