### PR TITLE
Deterministic corpus generation

### DIFF
--- a/lxmls/readers/sentiment_reader.py
+++ b/lxmls/readers/sentiment_reader.py
@@ -4,8 +4,8 @@ from __future__ import division
 import codecs
 
 import numpy as np
-import os
 from os import path
+from collections import OrderedDict
 
 
 class SentimentCorpus:
@@ -55,7 +55,7 @@ _base_sentiment_dir = path.join(path.dirname(__file__), "..", "..", "data", "sen
 def build_dicts(domain):
     """Builds feature dictionaries for a given domain of the sentiment analysis corpus."""
     sentiment_domains = ["books", "dvd", "electronics", "kitchen"]
-    feat_counts = {}
+    feat_counts = OrderedDict()
     if domain not in sentiment_domains:
         print(
             "Domain does not exist: \"%s\": Available are: %s" % 
@@ -101,7 +101,7 @@ def build_dicts(domain):
 
     nr_feat = len(feat_counts)
     # print nr_feat
-    feat_dict = {}
+    feat_dict = OrderedDict()
     i = 0
     # print "After removing %i %i"%(len(feat_counts),sum(feat_counts.values()))
     for key in list(feat_counts.keys()):

--- a/tests/test_non_linear_classifiers_numpy.py
+++ b/tests/test_non_linear_classifiers_numpy.py
@@ -12,8 +12,7 @@ from lxmls.deep_learning.utils import Model, glorot_weight_init, index2onehot, l
 from lxmls.deep_learning.numpy_models.mlp import NumpyMLP
 from lxmls.deep_learning.mlp import get_mlp_parameter_handlers, get_mlp_loss_range
 
-tolerance = 2 #TODO #FIXME Implementations give random results in a +-1 margin.
-              # Check the source of this randomness
+tolerance = 1e-2
 
 @pytest.fixture(scope='module')
 def corpus():

--- a/tests/test_non_linear_classifiers_pytorch.py
+++ b/tests/test_non_linear_classifiers_pytorch.py
@@ -13,8 +13,7 @@ from lxmls.deep_learning.utils import AmazonData
 from lxmls.deep_learning.utils import Model, glorot_weight_init
 from lxmls.deep_learning.pytorch_models.mlp import PytorchMLP
 
-tolerance = 2 #TODO #FIXME: Pytorch gives random results in a +-2 margin.
-              # Check the source of this randomness
+tolerance = 1e-2
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
This PR fixes #90. ``build_dicts`` was not deterministic through different runs (although it was deterministic when called twice in the same run), for python < 3.6.

Thanks @pedrobalage for writing the tests using python 3.6, so I don't have to update the values to check for :p