### PR TITLE
Replace deprecated usage of numpy.matrix by numpy.array

### DIFF
--- a/lxmls/parsing/dependency_decoder.py
+++ b/lxmls/parsing/dependency_decoder.py
@@ -22,8 +22,8 @@ class DependencyDecoder:
 
         nw = nr - 1
 
-        s = np.matrix(scores)
-        lap = np.matrix(np.zeros((nw+1, nw+1)))
+        s = np.array(scores)
+        lap = np.array(np.zeros((nw+1, nw+1)))
         for m in range(1, nw+1):
             d = 0.0
             for h in range(0, nw+1):


### PR DESCRIPTION
Fix #128.