### PR TITLE
Allow running specific tests when calling tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,5 @@ deps =
     py36-linux: http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl 
 
 changedir = tests
-commands = pytest
+commands = pytest {posargs}
+


### PR DESCRIPTION
Example usage:

```bash
tox test_parsing.py::test_exercise_4
```