### PR TITLE
Fix parameter name and variable cast

### DIFF
--- a/lxmls/deep_learning/pytorch_models/rnn.py
+++ b/lxmls/deep_learning/pytorch_models/rnn.py
@@ -73,7 +73,7 @@ class PytorchRNN(RNN):
             # Update weight
             self.parameters[m].data -= learning_rate * gradients[m]
 
-    def _log_forward(self, linput):
+    def _log_forward(self, input):
         """
         Forward pass
         """
@@ -126,7 +126,9 @@ class PytorchRNN(RNN):
         Computes the gradients of the network with respect to cross entropy
         error cost
         """
-        output = cast_float(output,grad=False)
+        
+        # Ensure the type matches torch type
+        output = Variable(torch.from_numpy(output).long())
 
         # Zero gradients
         for parameter in self.parameters:


### PR DESCRIPTION
1) Fixes typo in parameter name from "linput" to "input" which seems to be the intended name
2) Can anyone confirm that the variable cast does not have any unintended repercussions in the rest of the code base? The loss function seems to expect a long type while the conversion was to float.