### PR TITLE
Remove redundant (and forgotten) dependencies from tox.ini

### DIFF
--- a/lxmls/deep_learning/pytorch_models/rnn.py
+++ b/lxmls/deep_learning/pytorch_models/rnn.py
@@ -1,9 +1,11 @@
 from __future__ import division
+
 import numpy as np
 import scipy
 import scipy.linalg
 import torch
 from torch.autograd import Variable
+from torch.distributions import Categorical
 from lxmls.deep_learning.rnn import RNN
 # To sample from model
 from itertools import chain
@@ -296,7 +298,7 @@ class PolicyRNN(FastPytorchRNN):
         :return the samples and its neg. log probabilities
         """
         logits = self._log_forward(input)
-        distribution = torch.distributions.categorical.Categorical(
+        distribution = Categorical(
             logits=logits.view(-1, logits.size(-1))
         )
         samples = distribution.sample()

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,12 @@ filterwarnings =
     error
     ignore::UserWarning
     ignore::RuntimeWarning
-	
+    
 [tox]
 envlist =
-	py{27,35,36}-{linux,osx,windows}
+    #py{27,35,36}-{linux,osx,windows}
+    #py36-{linux,osx,windows}
+    py36
 
 [testenv]
 platform = linux: linux
@@ -20,30 +22,19 @@ platform = linux: linux
            windows: win32
 ; simplify numpy installation
 setenv =
-	LAPACK=
-	ATLAS=None
-	PYTHONWARNINGS=ignore
-	LANG=en_US.UTF-8
-	LANGUAGE=en_US:en
-	LC_ALL=en_US.UTF-8
+    LAPACK=
+    ATLAS=None
+    PYTHONWARNINGS=ignore
+    LANG=en_US.UTF-8
+    LANGUAGE=en_US:en
+    LC_ALL=en_US.UTF-8
 
 usedevelop = True
 
 deps =
-	six
-	pytest
-	pytest-xdist
-	numpy
-	scipy
-	nltk
-	matplotlib
-    py27-osx: http://download.pytorch.org/whl/torch-0.3.1-cp27-none-macosx_10_6_x86_64.whl 
-    py35-osx: http://download.pytorch.org/whl/torch-0.3.1-cp35-cp35m-macosx_10_6_x86_64.whl
-    py36-osx: http://download.pytorch.org/whl/torch-0.3.1-cp36-cp36m-macosx_10_7_x86_64.whl  
-    py27-linux: http://download.pytorch.org/whl/cpu/torch-0.3.1-cp27-cp27mu-linux_x86_64.whl 
-    py35-linux: http://download.pytorch.org/whl/cpu/torch-0.3.1-cp35-cp35m-linux_x86_64.whl 
-    py36-linux: http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl 
+    pytest
+    pytest-xdist
+    -rrequirements.txt
 
-changedir = tests
-commands = pytest {posargs}
+commands = pytest {posargs:tests}
 


### PR DESCRIPTION
Fix #135. Rollback importing Categorical.