### PR TITLE
Fix TravisCI config to allow using tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
   - linux
 
 install:
-  - pip install -r requirements.txt
+  - pip install tox
 
 script: tox
 


### PR DESCRIPTION
Fix TravisCI configuration that was also specifying the PyTorch version (see #135) and speed tests a bit, by making some methods run fewer epochs and also by parallelizing pytest.