### PR TITLE
Autoreload modules

### DIFF
--- a/labs/notebooks/basic_tutorials/Exercises_0.10_to_0.14.ipynb
+++ b/labs/notebooks/basic_tutorials/Exercises_0.10_to_0.14.ipynb
@@ -30,6 +30,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from lxmls.readers import galton"
    ]
   },

--- a/labs/notebooks/linear_classifiers/exercises.ipynb
+++ b/labs/notebooks/linear_classifiers/exercises.ipynb
@@ -16,6 +16,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {
     "collapsed": true

--- a/labs/notebooks/non_linear_classifiers/exercise_1.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_1.ipynb
@@ -22,6 +22,18 @@
    },
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",
     "corpus = srs.SentimentCorpus(\"books\")\n",

--- a/labs/notebooks/non_linear_classifiers/exercise_2.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_2.ipynb
@@ -15,6 +15,18 @@
    },
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",

--- a/labs/notebooks/non_linear_classifiers/exercise_3.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_3.ipynb
@@ -15,6 +15,18 @@
    },
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",
     "corpus = srs.SentimentCorpus(\"books\")\n",

--- a/labs/notebooks/non_linear_classifiers/exercise_4.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_4.ipynb
@@ -15,6 +15,18 @@
    },
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",
     "corpus = srs.SentimentCorpus(\"books\")\n",

--- a/labs/notebooks/non_linear_sequence_classifiers/exercise_1.ipynb
+++ b/labs/notebooks/non_linear_sequence_classifiers/exercise_1.ipynb
@@ -8,6 +8,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/labs/notebooks/non_linear_sequence_classifiers/exercise_2.ipynb
+++ b/labs/notebooks/non_linear_sequence_classifiers/exercise_2.ipynb
@@ -15,6 +15,18 @@
    },
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "# Load Part-of-Speech data \n",
     "from lxmls.readers.pos_corpus import PostagCorpusData\n",
     "data = PostagCorpusData()"

--- a/labs/notebooks/parsing/exercise_3.ipynb
+++ b/labs/notebooks/parsing/exercise_3.ipynb
@@ -18,6 +18,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
    "metadata": {
     "collapsed": false

--- a/labs/notebooks/parsing/exercise_4.ipynb
+++ b/labs/notebooks/parsing/exercise_4.ipynb
@@ -8,6 +8,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/labs/notebooks/reinforcement_learning/exercise_1_3_solutions.ipynb
+++ b/labs/notebooks/reinforcement_learning/exercise_1_3_solutions.ipynb
@@ -13,6 +13,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/labs/notebooks/reinforcement_learning/exercise_5.ipynb
+++ b/labs/notebooks/reinforcement_learning/exercise_5.ipynb
@@ -8,6 +8,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/labs/notebooks/reinforcement_learning/exercises_1_4.ipynb
+++ b/labs/notebooks/reinforcement_learning/exercises_1_4.ipynb
@@ -20,6 +20,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/labs/notebooks/sequence_models/Exercises_2.1_to_2.11.ipynb
+++ b/labs/notebooks/sequence_models/Exercises_2.1_to_2.11.ipynb
@@ -2,6 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
This solves issue #118 and was discussed in https://github.com/LxMLS/lxmls-guide/issues/74 as well.

I've added the autoreload command to all exercises, even if they don't necessarily ask the students to change the `lxmls` module. This way, it works even if they decide to do so themselves, eg. to modify the `galton` data.