### PR TITLE
Ignore DeprecationWarning and PendingDeprecationWarning during tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ filterwarnings =
     error
     ignore::UserWarning
     ignore::RuntimeWarning
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
     
 [tox]
 envlist =


### PR DESCRIPTION
This is currently required, because matplotlib imports LooseVersion which imports imp, which is deprecated.