### PR TITLE
Updated system path to include lxmls library

### DIFF
--- a/labs/notebooks/learning_structured_predictors/exercise_1.ipynb
+++ b/labs/notebooks/learning_structured_predictors/exercise_1.ipynb
@@ -28,6 +28,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "from lxmls import DATA_PATH\n",
     "import lxmls\n",
     "import lxmls.sequences.crf_online as crfo\n",

--- a/labs/notebooks/learning_structured_predictors/exercise_2.ipynb
+++ b/labs/notebooks/learning_structured_predictors/exercise_2.ipynb
@@ -28,6 +28,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "from lxmls import DATA_PATH\n",
     "import lxmls\n",
     "import lxmls.sequences.crf_online as crfo\n",

--- a/labs/notebooks/learning_structured_predictors/exercise_3.ipynb
+++ b/labs/notebooks/learning_structured_predictors/exercise_3.ipynb
@@ -28,6 +28,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "from lxmls import DATA_PATH\n",
     "import lxmls\n",
     "import lxmls.sequences.crf_online as crfo\n",

--- a/labs/notebooks/learning_structured_predictors/exercise_4.ipynb
+++ b/labs/notebooks/learning_structured_predictors/exercise_4.ipynb
@@ -21,6 +21,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "from lxmls import DATA_PATH\n",
     "import lxmls\n",
     "import lxmls.sequences.crf_online as crfo\n",

--- a/labs/notebooks/linear_classifiers/exercises.ipynb
+++ b/labs/notebooks/linear_classifiers/exercises.ipynb
@@ -34,6 +34,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "import lxmls.readers.sentiment_reader as srs\n",
     "scr = srs.SentimentCorpus(\"books\")"
    ]

--- a/labs/notebooks/non_linear_classifiers/exercise_1.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_1.ipynb
@@ -34,6 +34,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",
     "corpus = srs.SentimentCorpus(\"books\")\n",

--- a/labs/notebooks/non_linear_classifiers/exercise_2.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_2.ipynb
@@ -27,6 +27,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "import numpy as np\n",
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",

--- a/labs/notebooks/non_linear_classifiers/exercise_3.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_3.ipynb
@@ -27,6 +27,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",
     "corpus = srs.SentimentCorpus(\"books\")\n",

--- a/labs/notebooks/non_linear_classifiers/exercise_4.ipynb
+++ b/labs/notebooks/non_linear_classifiers/exercise_4.ipynb
@@ -27,6 +27,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "import lxmls.readers.sentiment_reader as srs\n",
     "from lxmls.deep_learning.utils import AmazonData\n",
     "corpus = srs.SentimentCorpus(\"books\")\n",

--- a/labs/notebooks/non_linear_sequence_classifiers/exercise_1.ipynb
+++ b/labs/notebooks/non_linear_sequence_classifiers/exercise_1.ipynb
@@ -47,6 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "# Load Part-of-Speech data \n",
     "from lxmls.readers.pos_corpus import PostagCorpusData\n",
     "data = PostagCorpusData()"

--- a/labs/notebooks/non_linear_sequence_classifiers/exercise_2.ipynb
+++ b/labs/notebooks/non_linear_sequence_classifiers/exercise_2.ipynb
@@ -27,6 +27,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "# Load Part-of-Speech data \n",
     "from lxmls.readers.pos_corpus import PostagCorpusData\n",
     "data = PostagCorpusData()"

--- a/labs/notebooks/reinforcement_learning/exercise_5.ipynb
+++ b/labs/notebooks/reinforcement_learning/exercise_5.ipynb
@@ -39,6 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys; sys.path.append(\"../../../\")\n",
     "# Load Part-of-Speech data \n",
     "from lxmls.readers.pos_corpus import PostagCorpusData\n",
     "data = PostagCorpusData()"

--- a/labs/notebooks/reinforcement_learning/exercises_1_4.ipynb
+++ b/labs/notebooks/reinforcement_learning/exercises_1_4.ipynb
@@ -26,7 +26,8 @@
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
-    "%autoreload 2"
+    "%autoreload 2",
+    "import sys; sys.path.append(\"../../../\")\n"
    ]
   },
   {


### PR DESCRIPTION
For me, Jupyter was always unable to load the `lxmls` package. This can be solved by updating the system path, which I included now.
Previously, the only notebook which did this as well was exercise 3 for parsing.

How did everybody else run the notebooks so far? I remember having the same issues last year as a student, but I guess it must have worked for most people, or this would have been fixed earlier?