### PR TITLE
Fix in RL exercises: Q-Learning and Value Iteration

### DIFF
--- a/labs/notebooks/reinforcement_learning/exercises_1_4.ipynb
+++ b/labs/notebooks/reinforcement_learning/exercises_1_4.ipynb
@@ -165,7 +165,7 @@
     "    state=random.randint(0, 2) \n",
     "    action=random.randint(0, 2) \n",
     "    next_state=action\n",
-    "    reward=rewards[next_state] \n",
+    "    reward=raw_rewards[next_state] \n",
     "    next_q=max(q_table[next_state]) \n",
     "    q_table[state, action]= #TODO: Implement the Q-Table update\n",
     "    if i%100==0:\n",
@@ -209,7 +209,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "rewards=np.array([10., 2., 3.])\n",
+    "raw_rewards = np.array([1.5, -1.833333333, 19.833333333])\n",
     "gamma = 0.1\n",
     "\n",
     "state_value_function = np.zeros(3)\n",


### PR DESCRIPTION
I should have fixed it a year ago.

I had already added the same fix in `exercise_1_3_solutions.ipynb` (master branch), commit cef22423, a long ago.

However that time I forgot to add the same update in `exercises_1_4.ipynb` (master and student branches both contain this file).

So, let's add the same small but important fix here (I'm going to do it in master and student branches now synchronously).

Also, let me copy old commit (cef22423) message for reference:

> Use rewards obtained after transition to state (`raw_rewards` variable) instead of expected values of the next reward using original policy (`rewards` variable) in both Policy Optimization exercises.
> In Value Iteration exercise also use next state (`s_next` variable) instead of source state (`s` variable) for reward indexing. Though according to `s_prime` variable name in original code maybe it was an attempt to perform Value Iteration in "backward direction" but I haven't managed to make such code produce correct results (and didn't see any algorithm working this way) so just implemented classic one (like in Sutton book).
> 
> Now all 3 optimal state Values are equal. And this is correct as in our particular MRP example reward only depends on next state, not on source state so initial state doesn't affect reward for optimal policy.

---

Counterpart pull request for `student` branch: #171