### PR TITLE
Remove codecs.open

### DIFF
--- a/labs/remove_ipython_inline.py
+++ b/labs/remove_ipython_inline.py
@@ -2,7 +2,7 @@
 Removes get_ipython() inline calls from scripts
 """
 import re
-import codecs
+
 import sys
 
 EXCLUDE_LINES = re.compile('[^#]*get_ipython().*')
@@ -20,7 +20,7 @@ if __name__ == '__main__':
         exit(1)
 
     # Line filtering
-    with codecs.open(script_file, 'r', 'utf-8') as fid:
+    with open(script_file, 'r', 'utf-8') as fid:
         new_lines = []
         for line in fid.readlines():
             if EXCLUDE_LINES.match(line.strip()):
@@ -29,6 +29,6 @@ if __name__ == '__main__':
                 new_lines.append(line)
 
     # Rewrite file
-    with codecs.open(script_file, 'w', 'utf-8') as fid:
+    with open(script_file, 'w', 'utf-8') as fid:
         for line in new_lines:
             fid.write(line)

--- a/lxmls/pos_tagging/all_train_pos_tag.py
+++ b/lxmls/pos_tagging/all_train_pos_tag.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import codecs
+
 
 from lxmls import data
 from sequences.sequence import *

--- a/lxmls/readers/pos_corpus.py
+++ b/lxmls/readers/pos_corpus.py
@@ -117,7 +117,7 @@ class PostagCorpus(object):
             reader = codecs.getreader("utf-8")
             contents = reader(zf)
         else:
-            contents = codecs.open(file, "r", "utf-8")
+            contents = open(file, "r", "utf-8")
 
         nr_sent = 0
         instances = []
@@ -155,7 +155,7 @@ class PostagCorpus(object):
         """Dumps a corpus into a file"""
         if not os.path.isdir(dir + "/"):
             os.mkdir(dir + "/")
-        word_fn = codecs.open(dir + "word.dic", "w", "utf-8")
+        word_fn = open(dir + "word.dic", "w", "utf-8")
         for word_id, word in enumerate(self.int_to_word):
             word_fn.write("%i\t%s\n" % (word_id, word))
         word_fn.close()
@@ -171,7 +171,7 @@ class PostagCorpus(object):
 
     def load_corpus(self, dir):
         """Loads a corpus from a file"""
-        word_fn = codecs.open(dir + "word.dic", "r", "utf-8")
+        word_fn = open(dir + "word.dic", "r", "utf-8")
         for line in word_fn:
             word_nr, word = line.strip().split("\t")
             self.int_to_word.append(word)

--- a/lxmls/readers/sentiment_reader.py
+++ b/lxmls/readers/sentiment_reader.py
@@ -1,7 +1,7 @@
 # http://www.scipy.org/SciPyPackages/Sparse
 from __future__ import division
 
-import codecs
+
 
 import numpy as np
 from os import path
@@ -65,7 +65,7 @@ def build_dicts(domain):
 
     # Build Dictionarie wit counts
     nr_pos = 0
-    pos_file = codecs.open(path.join(_base_sentiment_dir, domain, "positive.review"), 'r', 'utf8')
+    pos_file = open(path.join(_base_sentiment_dir, domain, "positive.review"), 'r', 'utf8')
     for line in pos_file:
         nr_pos += 1
         toks = line.split(" ")
@@ -76,7 +76,7 @@ def build_dicts(domain):
             feat_counts[name] += int(counts)
     pos_file.close()
     nr_neg = 0
-    neg_file = codecs.open(path.join(_base_sentiment_dir, domain, "negative.review"), 'r', 'utf8')
+    neg_file = open(path.join(_base_sentiment_dir, domain, "negative.review"), 'r', 'utf8')
     for line in neg_file:
         nr_neg += 1
         toks = line.split(" ")
@@ -110,7 +110,7 @@ def build_dicts(domain):
 
     X = np.zeros((size, nr_feat), dtype=float)
     y = np.vstack((np.zeros([nr_pos, 1], dtype=int), np.ones([nr_neg, 1], dtype=int)))
-    pos_file = codecs.open(path.join(_base_sentiment_dir, domain, "positive.review"), 'r', 'utf8')
+    pos_file = open(path.join(_base_sentiment_dir, domain, "positive.review"), 'r', 'utf8')
     nr_pos = 0
     for line in pos_file:
         toks = line.split(" ")
@@ -120,7 +120,7 @@ def build_dicts(domain):
                 # print "adding %s with counts %s"%(name,counts)
                 X[nr_pos, feat_dict[name]] = int(counts)
         nr_pos += 1
-    neg_file = codecs.open(path.join(_base_sentiment_dir, domain, "negative.review"), 'r', 'utf8')
+    neg_file = open(path.join(_base_sentiment_dir, domain, "negative.review"), 'r', 'utf8')
     nr_neg = 0
     for line in neg_file:
         toks = line.split(" ")


### PR DESCRIPTION
This pull request replaces all instances of `codecs.open` with open and removes unnecessary imports.