### PR TITLE
fix: Rename non-linear sequence classifier exercises to day 3.

### DIFF
--- a/labs/notebooks/non_linear_sequence_classifiers/exercise_1.ipynb
+++ b/labs/notebooks/non_linear_sequence_classifiers/exercise_1.ipynb
@@ -4,14 +4,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Day 6: Sequence Models in Deep Learning"
+    "# Day 3: Sequence Models in Deep Learning"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -23,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercise 6.1 \n",
+    "### Exercise 3.1 \n",
     "Convince yourself that a RNN is just an FF unfolded in time. Complete the `backpropagation()` method in the `NumpyRNN` class in \n",
     "\n",
     "    lxmls/deep_learning/numpy_models/rnn.py \n",
@@ -224,7 +227,7 @@
    "suppress_outputs": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -238,9 +241,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/labs/notebooks/non_linear_sequence_classifiers/exercise_2.ipynb
+++ b/labs/notebooks/non_linear_sequence_classifiers/exercise_2.ipynb
@@ -32,7 +32,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Check Numpy and Pytorch Gradients match\n",
+    "### Exercise 3.2\n",
+    "#### Check Numpy and Pytorch Gradients match\n",
     "As we did with the feed-forward network, we will no implement a Recurrent Neural Network (RNN) in Pytorch. For this complete the log `forward()` method in \n",
     "\n",
     "    lxmls/deep_learning/pytorch_models/rnn.py\n",
@@ -237,9 +238,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Exercises were previously marked as day 6 but they are on day 3 on the guide (at least the one on Overleaf that I checked today).