### PR TITLE
fix: Change embeddings matrix shape to (E,I) on RNN

### DIFF
--- a/lxmls/deep_learning/rnn.py
+++ b/lxmls/deep_learning/rnn.py
@@ -51,7 +51,7 @@ def initialize_rnn_parameters(input_size, embedding_size, hidden_size,
         W_e, W_x, W_h, W_y = loaded_parameters
 
         # Note: Pytorch requires this shape order fro nn.Embedding()
-        assert W_e.shape == (input_size, embedding_size), \
+        assert W_e.shape == (embedding_size, input_size), \
             "Embedding layer ze not matching saved model"
         assert W_x.shape == (hidden_size, embedding_size), \
             "Input layer ze not matching saved model"
@@ -65,7 +65,7 @@ def initialize_rnn_parameters(input_size, embedding_size, hidden_size,
         # INITIALIZE
 
         # Input layer
-        W_e = 0.01*random_seed.uniform(size=(input_size, embedding_size))
+        W_e = 0.01*random_seed.uniform(size=(embedding_size, input_size))
         # Input layer
         W_x = random_seed.uniform(size=(hidden_size, embedding_size))
         # Recurrent layer

--- a/tests/test_sequence_models_deep_learning.py
+++ b/tests/test_sequence_models_deep_learning.py
@@ -14,7 +14,7 @@ tolerance = 1e-2
 
 
 @pytest.fixture(scope='module')
-def data(): 
+def data():
     return PostagCorpusData()
 
 
@@ -33,7 +33,7 @@ def test_numpy_rnn(data):
     # Get functions to get and set values of a particular weight of the model
     get_parameter, set_parameter = get_rnn_parameter_handlers(
         layer_index=-1,
-        row=0, 
+        row=0,
         column=0
     )
 
@@ -68,21 +68,21 @@ def test_numpy_rnn(data):
 
         # Batch loop
         for batch in train_batches:
-            model.update(input=batch['input'], output=batch['output'])
+            model.update(model_input=batch['input'], output=batch['output'])
 
         # Evaluation dev
         is_hit = []
         for batch in dev_set:
-            is_hit.extend(model.predict(input=batch['input']) == batch['output'])
+            is_hit.extend(model.predict(model_input=batch['input']) == batch['output'])
         accuracy = 100*np.mean(is_hit)
 
     # tested for 2 epochs only
     assert np.allclose(accuracy, 31.325, tolerance)
-        
+
     # Evaluation test
     is_hit = []
     for batch in test_set:
-        is_hit.extend(model.predict(input=batch['input']) == batch['output'])
+        is_hit.extend(model.predict(model_input=batch['input']) == batch['output'])
     accuracy = 100*np.mean(is_hit)
 
     assert np.allclose(accuracy, 30.105, tolerance)
@@ -122,7 +122,7 @@ def test_pytorch_rnn(data):
 
     # tested for 2 epochs only
     assert np.allclose(accuracy, 31.325, tolerance)
-        
+
     # Evaluation test
     is_hit = []
     for batch in test_set:


### PR DESCRIPTION
On Algorithms 9 and 10, the embeddings matrix $\mathbf{W}^e \in \mathbb{R}^{E \times I}$ was shape $(E, I)$. The initialization of the RNN on `lxmls/deep_learning/rnn.py` initializes a $\mathbf{W}^e$ with shape  $(I, E)$ `(input_size, embedding_size)` instead.

This change makes $\mathbf{W}^e$ have shape  $(E, I)$ and also updates the `NumpyRNN.log_forward` method to account for the new shape.

Also on this PR is the rename of the argument `input` (a python builtin function) to `model_input* across multiple functions. Maybe we want to move this to a different PR.